### PR TITLE
Alerts & Additional data for firefox installs

### DIFF
--- a/firefox-install-demo.toml
+++ b/firefox-install-demo.toml
@@ -10,11 +10,13 @@ skip_default_metrics = true
 
 metrics = [
     "install_success_rate",
-    "install_volume",
+    "install_volume_by_os_version",
+    "install_volume_total",
 ]
 
 alerts = [
-    "install_success_rate"
+    "install_success_rate",
+    "install_volume_total",
 ]
 
 [project.population]
@@ -40,13 +42,21 @@ type = "scalar"
 [metrics.install_success_rate.statistics]
 mean = {}
 
-[metrics.install_volume]
+[metrics.install_volume_by_os_version]
 data_source = "firefox_installs"
 select_expression = "IF(LOGICAL_OR(succeeded), 1, 0) * 100"
 type = "scalar"
 
-[metrics.install_volume.statistics]
-mean = {}
+[metrics.install_volume_by_os_version.statistics]
+sum = {}
+
+[metrics.install_volume_total]
+data_source = "firefox_installs_all_versions"
+select_expression = "IF(LOGICAL_OR(succeeded), 1, 0) * 100"
+type = "scalar"
+
+[metrics.install_volume_total.statistics]
+sum = {}
 
 [alerts]
 
@@ -57,6 +67,18 @@ metrics = [
 ]
 # is this per os version, or average over all, or....?
 min = [95]
+
+[alerts.install_volume_total]
+type = "avg_diff"
+metrics = [
+    "install_volume_total"
+]
+# is this a rolling window, eg: comparing monday -> sunday to monday -> tuesday
+# or comparing the entire previous week?
+window_size = 7
+# does this mean a drop of 20% will trigger an alert (eg: 100 -> 80), or a drop of 80% (eg: 100 -> 20)?
+max_relative_change = 0.8
+# percentile omitted because it doesn't apply here? Is that valid?
 
 [data_sources]
 
@@ -76,6 +98,41 @@ from_expression = """
                     WHEN os_version LIKE '10%' THEN 'Win10'
                     ELSE "other"
                 END as branch,
+            FROM mozdata.firefox_installer.install
+            WHERE 
+                build_channel = "release"
+                AND installer_type = 'stub'
+        )
+        SELECT 
+        submission_date,
+        document_id,
+        build_channel,
+        succeeded,
+        STRUCT (    -- this is the structure opmon expects
+            [
+            STRUCT (
+                "firefox-install-demo" AS key,   -- dummy experiment/rollout slug to make opmon happy
+                STRUCT(branch AS branch) AS value
+            )
+            ] AS experiments
+        ) AS environment
+        FROM success_rate_per_branch
+        WHERE branch != "other"
+    )
+"""
+submission_date_column = "submission_date"
+client_id_column = "document_id"
+
+[data_sources.firefox_installs_all_versions]
+from_expression = """
+    (
+        WITH success_rate_per_branch AS (
+            SELECT 
+                DATE(submission_timestamp) AS submission_date,
+                document_id,
+                build_channel,
+                succeeded,
+                "All versions" AS branch,
             FROM mozdata.firefox_installer.install
             WHERE 
                 build_channel = "release"

--- a/firefox-install-demo.toml
+++ b/firefox-install-demo.toml
@@ -10,6 +10,7 @@ skip_default_metrics = true
 
 metrics = [
     "install_success_rate",
+    "install_volume",
 ]
 
 alerts = [
@@ -37,7 +38,14 @@ select_expression = "IF(LOGICAL_OR(succeeded), 1, 0) * 100"
 type = "scalar"
 
 [metrics.install_success_rate.statistics]
-sum = {}
+mean = {}
+
+[metrics.install_volume]
+data_source = "firefox_installs"
+select_expression = "IF(LOGICAL_OR(succeeded), 1, 0) * 100"
+type = "scalar"
+
+[metrics.install_volume.statistics]
 mean = {}
 
 [alerts]

--- a/firefox-install-demo.toml
+++ b/firefox-install-demo.toml
@@ -12,6 +12,10 @@ metrics = [
     "install_success_rate",
 ]
 
+alerts = [
+    "install_success_rate"
+]
+
 [project.population]
 
 data_source = "firefox_installs"
@@ -35,6 +39,16 @@ type = "scalar"
 [metrics.install_success_rate.statistics]
 sum = {}
 mean = {}
+
+[alerts]
+
+[alerts.install_success_rate]
+type = "threshold"
+metrics = [
+    "install_success_rate"
+]
+# is this per os version, or average over all, or....?
+min = [95]
 
 [data_sources]
 

--- a/firefox-install-demo.toml
+++ b/firefox-install-demo.toml
@@ -11,12 +11,10 @@ skip_default_metrics = true
 metrics = [
     "install_success_rate",
     "install_volume_by_os_version",
-    "install_volume_total",
 ]
 
 alerts = [
     "install_success_rate",
-    "install_volume_total",
 ]
 
 [project.population]
@@ -50,14 +48,6 @@ type = "scalar"
 [metrics.install_volume_by_os_version.statistics]
 sum = {}
 
-[metrics.install_volume_total]
-data_source = "firefox_installs_all_versions"
-select_expression = "IF(LOGICAL_OR(succeeded), 1, 0) * 100"
-type = "scalar"
-
-[metrics.install_volume_total.statistics]
-sum = {}
-
 [alerts]
 
 [alerts.install_success_rate]
@@ -67,18 +57,6 @@ metrics = [
 ]
 # is this per os version, or average over all, or....?
 min = [95]
-
-[alerts.install_volume_total]
-type = "avg_diff"
-metrics = [
-    "install_volume_total"
-]
-# is this a rolling window, eg: comparing monday -> sunday to monday -> tuesday
-# or comparing the entire previous week?
-window_size = 7
-# does this mean a drop of 20% will trigger an alert (eg: 100 -> 80), or a drop of 80% (eg: 100 -> 20)?
-max_relative_change = 0.8
-# percentile omitted because it doesn't apply here? Is that valid?
 
 [data_sources]
 
@@ -98,41 +76,6 @@ from_expression = """
                     WHEN os_version LIKE '10%' THEN 'Win10'
                     ELSE "other"
                 END as branch,
-            FROM mozdata.firefox_installer.install
-            WHERE 
-                build_channel = "release"
-                AND installer_type = 'stub'
-        )
-        SELECT 
-        submission_date,
-        document_id,
-        build_channel,
-        succeeded,
-        STRUCT (    -- this is the structure opmon expects
-            [
-            STRUCT (
-                "firefox-install-demo" AS key,   -- dummy experiment/rollout slug to make opmon happy
-                STRUCT(branch AS branch) AS value
-            )
-            ] AS experiments
-        ) AS environment
-        FROM success_rate_per_branch
-        WHERE branch != "other"
-    )
-"""
-submission_date_column = "submission_date"
-client_id_column = "document_id"
-
-[data_sources.firefox_installs_all_versions]
-from_expression = """
-    (
-        WITH success_rate_per_branch AS (
-            SELECT 
-                DATE(submission_timestamp) AS submission_date,
-                document_id,
-                build_channel,
-                succeeded,
-                "All versions" AS branch,
             FROM mozdata.firefox_installer.install
             WHERE 
                 build_channel = "release"


### PR DESCRIPTION
There's a few changes/enhancements being made here:
1) Adding a simple threshold alert for the existing `install_success_rate` metric. I'm pretty sure this is right, except that I'm not clear on whether or not a `max` must be provided as well? (In our case, we don't care if we go over some max - it should never be higher than 100 anyways...)
2) Separating out the `install_success_rate` sum into a separate metric, hopefully to improve the name ("Install success rate" on a sum is weird...maybe I should be renaming the existing metric instead though rather than duplicating?)
3) Attempting to add an additional metric and alert for total (ie: not separated by platform) install volume. This one I'm sure is messed up in at least one way. For one, because we're not breaking out by platform there's only one "branch" - and I don't know if that will break any assumptions made by OpMon. I'm also not sure the alert makes any sense, since I _think_ we were told in #50 that percentiles are simply not applicable here due to lack of a consistent `client_id`. In any case, the goal here is to have an alert if total install volume drops below some threshold -- preferably one that's defined over a 7 day period to account for our weekend dip - so any suggestions on that would be welcomed.