### PR TITLE
Adjust install success rate alert threshold

### DIFF
--- a/firefox-install-demo.toml
+++ b/firefox-install-demo.toml
@@ -55,8 +55,10 @@ type = "threshold"
 metrics = [
     "install_success_rate"
 ]
-# is this per os version, or average over all, or....?
-min = [95]
+# This one number is applied to each OS, unfortunately. Ideally
+# we would have per-branch configuration, since each Windows version
+# has its own fairly steady success rate.
+min = [86]
 
 [data_sources]
 


### PR DESCRIPTION
As far as I can tell, we can't adjust this per-branch, so this is the best we can do for now. Alternatively, we could:
- Only measure overall success rate (ie: one line per graph). This would mean we wouldn't necessarily see a drop from just one OS version though
- Use separate data sources and metrics per os version (and forego branches altogether). There may be downsides to this I'm not aware of though?